### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/msapmdemo/abebd2e9-e0d6-428b-b47e-49812ec6f39f/18073d9d-45e4-4c91-b89c-46cba57203dc/_apis/work/boardbadge/695d68af-f573-44fc-b4e8-c822008a7959)](https://dev.azure.com/msapmdemo/abebd2e9-e0d6-428b-b47e-49812ec6f39f/_boards/board/t/18073d9d-45e4-4c91-b89c-46cba57203dc/Microsoft.RequirementCategory)
 # teamsapp


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1852](https://dev.azure.com/msapmdemo/abebd2e9-e0d6-428b-b47e-49812ec6f39f/_workitems/edit/1852). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.